### PR TITLE
Updates for Ruby 2.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ unless ''.respond_to?(:encoding)
   exit 1
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rbconfig'
 
 desc 'Run specs by default'
@@ -13,7 +13,7 @@ task :default => :spec
 
 desc 'Run all specs'
 task :spec do
-  ruby = File.join(*Config::CONFIG.values_at('bindir', 'ruby_install_name'))
+  ruby = File.join(*RbConfig::CONFIG.values_at('bindir', 'ruby_install_name'))
   FileList[File.expand_path('../spec/**/*_spec.rb', __FILE__)].each do |spec|
     sh "#{ruby} #{spec}"
   end

--- a/ensure-encoding.gemspec
+++ b/ensure-encoding.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files = FileList['README.rdoc', 'LICENSE', 'lib/**/*.rb'].to_a
 
-  spec.has_rdoc = true
   spec.extra_rdoc_files = ['README.rdoc', 'LICENSE']
   spec.rdoc_options << "--all" << "--charset" << "utf-8"
 end

--- a/lib/ensure/encoding.rb
+++ b/lib/ensure/encoding.rb
@@ -64,7 +64,7 @@ module Ensure
         raise ::Encoding::InvalidByteSequenceError, "String is not encoded as `#{target_encoding}'" unless string.valid_encoding?
       else
         filters = (options[:invalid_characters] == :drop) ? { :replace => '', :undef => :replace, :invalid => :replace } : {}
-        string.encode!(target_encoding, external_encoding, filters)
+        string.encode!(target_encoding, external_encoding, **filters)  # https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/
       end
     end
     

--- a/spec/api/ensure_encoding_spec.rb
+++ b/spec/api/ensure_encoding_spec.rb
@@ -50,6 +50,24 @@ describe "Ensure::Encoding, concerning force_encoding with the external_encoding
     result.should == data_in_utf8
   end
   
+  it "should sniff encoding from the UTF-16LE character data" do
+    example, data_in_utf8 = example('UTF-16LE')
+    bom = Ensure::Encoding::BYTE_ORDER_MARKS[::Encoding::UTF_8].pack("C3").force_encoding('UTF-8')
+
+    result = Ensure::Encoding.force_encoding(example, Encoding::UTF_8, :external_encoding => :sniff)
+    result.encoding.should == Encoding::UTF_8
+    result.should == bom + data_in_utf8
+  end
+
+  it "should sniff encoding from the UTF-16BE character data" do
+    example, data_in_utf8 = example('UTF-16BE')
+    bom = Ensure::Encoding::BYTE_ORDER_MARKS[::Encoding::UTF_8].pack("C3").force_encoding('UTF-8')
+
+    result = Ensure::Encoding.force_encoding(example, Encoding::UTF_8, :external_encoding => :sniff)
+    result.encoding.should == Encoding::UTF_8
+    result.should == bom + data_in_utf8
+  end
+
   it "should guess the encoding from the character data by trying the specified external encodings" do
     example, data_in_utf8 = example('Shift_JIS')
     result = Ensure::Encoding.force_encoding(example, Encoding::UTF_8, :external_encoding => [

--- a/spec/api/string_spec.rb
+++ b/spec/api/string_spec.rb
@@ -20,4 +20,24 @@ describe "String, extended with Ensure::Encoding::String" do
     example.ensure_encoding!('ISO-8859-1')
     example.encoding.should == Encoding::ISO_8859_1
   end
+
+  it "should force encoding to UTF-16LE" do
+    example = 'Café'
+
+    result = example.ensure_encoding('UTF-16LE')
+    result.encoding.should == Encoding::UTF_16LE
+
+    example.ensure_encoding!('UTF-16LE')
+    example.encoding.should == Encoding::UTF_16LE
+  end
+
+  it "should force encoding to UTF-16BE" do
+    example = 'Café'
+
+    result = example.ensure_encoding('UTF-16BE')
+    result.encoding.should == Encoding::UTF_16BE
+
+    example.ensure_encoding!('UTF-16BE')
+    example.encoding.should == Encoding::UTF_16BE
+  end
 end

--- a/spec/start.rb
+++ b/spec/start.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems' rescue LoadError
 require 'bacon'
-require 'mocha'
+require 'mocha-on-bacon' # https://github.com/alloy/mocha-on-bacon
 
 require 'fileutils'
 

--- a/spec/start.rb
+++ b/spec/start.rb
@@ -15,8 +15,8 @@ module EncodingTestHelpers
     'UTF-8'      => 'पशुपतिरपि तान्यहानि कृच्छ्राद्',
     'ISO-8859-1' => 'Prévisions météo de Météo-France',
     'Shift_JIS'  => 'こんにちは',
-    # 'UTF-16LE'   => '',
-    # 'UTF-16BE'   => ''
+    'UTF-16LE'   => 'Ἰοὺ ἰού· τὰ πάντʼ ἂν ἐξήκοι σαφῆ.',
+    'UTF-16BE'   => 'По оживлённым берегам'
   }
   
   def examples


### PR DESCRIPTION
This pull request primarily addresses a warning that appears with Ruby 2.7 (sources [here](https://bloggie.io/@kinopyo/how-to-fix-ruby-2-7-warning-using-the-last-argument-as-keyword-parameters-is-deprecated) and [here](https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/)):
```
Using the last argument as keyword parameters is deprecated
```
It also addresses this warning:
```
Gem::Specification#has_rdoc= is deprecated with no replacement
```
Lastly, I took the opportunity to expand test coverage for UTF-16LE and UTF-16BE as best I could, given my limited knowledge. Feel free to review for correctness.